### PR TITLE
added fancymenu hover styling

### DIFF
--- a/src/usr/share/lxqt/themes/Lubuntu Arc/lxqt-panel.qss
+++ b/src/usr/share/lxqt/themes/Lubuntu Arc/lxqt-panel.qss
@@ -541,8 +541,13 @@ TrayIcon {
     padding-right: 4px;
 }
 
+#FancyMenu QListView::item::hover {
+    color: rgb(210, 216, 224);
+    background: rgb(58, 63, 75);
+}
+
 #FancyMenu QListView::item::selected {
-    color: #D2D8E0;    
+    color: rgb(255, 255, 255);
     background: rgb(79, 86, 101);
 }
 
@@ -553,9 +558,14 @@ TrayIcon {
     padding-right: 2px;
 }
 
-#FancyMenu #AppView::item::selected  {
+#FancyMenu #AppView::item::hover  {
     color: #D2D8E0;
-    background: #3c8ce6;    
+    background: #3A597C;
+}
+
+#FancyMenu #AppView::item::selected  {
+    color:#E6E9EE;
+    background: #3c8ce6;
 }
 
 #FancyMenu QToolButton {


### PR DESCRIPTION
When testing the new FancyMenu (which is great btw), I initially thought there was a graphical glitch as menu items didn’t visibly respond as I moved the cursor across them. I then realized this perceived delay was because there was no hover styling like some other lxqt themes have.

This PR adds hover styling to menu items, providing immediate visual feedback as the user moves the cursor. This makes the interface feel more responsive IMO and helps distinguish between hover and actual selection. I suspect I'm not the only one who might mistake the delay for a rendering issue at first so I hope this helps.

I'm no designer, so I just tried to eyeball the colors. Here are before and after gifs.

Before: 
![before](https://github.com/user-attachments/assets/96001dfe-a40d-40fb-87f7-371f7b53e391)


After:
![after](https://github.com/user-attachments/assets/307b6e86-0b20-4e86-9094-7caa9fdbfbc2)
